### PR TITLE
Set Dock border to none, to fix position consistency of atom-dock.

### DIFF
--- a/Ozon/gnome-shell/gnome-shell.css
+++ b/Ozon/gnome-shell/gnome-shell.css
@@ -1096,7 +1096,7 @@ StScrollBar StButton#hhandle:active {
     background-gradient-start: transparent;
     background-gradient-end: transparent;
     background-color: transparent;
-    border-color: transparent;
+    border: none;
 }
 
 #dash:desktop {


### PR DESCRIPTION
The dock has 0px border in Desktop, but "transparent" border in Overview screen, meaning it still have a width. This leads to position inconsistency between the dock in desktop and in overview (I use height as a variable to determine it's y position, 1px border will make the dock shift 1px).
Because on overview screen, the background and border of dock is supposed to be transparent after all, I set the borded to none.
