### PR TITLE
Implemented bottom bar for dock's running app.

### DIFF
--- a/Ozon/gnome-shell/gnome-shell.css
+++ b/Ozon/gnome-shell/gnome-shell.css
@@ -1378,7 +1378,7 @@ StScrollBar StButton#hhandle:active {
     /*Border produces http://i.imgur.com/3Vbf6zo.png -_- */
     /* Terrible 20% opaque teal code */
     background-image: none;
-    border-color: rgba(238,238,238,1.0);
+    border-color: rgba(17,170,136,1.0);
     border-radius: 0px;
     /*background-gradient-direction: none;
     background-color: rgba(17,170,136,0.2);


### PR DESCRIPTION
Basically it will mark running app icon in dock with "underscore" instead of background color.

![see the dock](https://cloud.githubusercontent.com/assets/749098/2684912/352f9f6c-c1c0-11e3-87df-4d715890ce55.png)
